### PR TITLE
Camera cycling only on View action

### DIFF
--- a/ClientPlugin/ActivatePatch.cs
+++ b/ClientPlugin/ActivatePatch.cs
@@ -72,8 +72,10 @@ namespace ClientPlugin
 
         public static void HandleCameraGroup(List<MyTerminalBlock> terminalBlocks, ITerminalAction action)
         {
-            // All cameras?
-            if (terminalBlocks.Count != 0 && terminalBlocks.All(block => block is IMyCameraBlock))
+            // All cameras & action == View
+            if (terminalBlocks.Count != 0 && 
+                terminalBlocks.All(block => block is IMyCameraBlock) &&
+                action.Name.ToString() == "View")
             {
                 SelectNextCamera(terminalBlocks, action);
                 return;


### PR DESCRIPTION
The cycling Apply should only happen specifically when we're trying to `View` a group of `IMyCameraBlock`. Otherwise, the default `foreach Apply` logic should run.